### PR TITLE
Use console.error() to report errors

### DIFF
--- a/src/functions/newLolly.js
+++ b/src/functions/newLolly.js
@@ -36,7 +36,7 @@ exports.handler = (event, context, callback) => {
         console.log(response);
       })
       .catch(function (error) {
-        console.log(error);
+        console.error(error);
       });
 
       // Success! Go to a page to view the result
@@ -48,7 +48,7 @@ exports.handler = (event, context, callback) => {
         }
       });
     }).catch((error) => {
-      console.log('error', error);
+      console.error('error', error);
       // Error! return the error with statusCode 400
       return callback(null, {
         statusCode: 400,


### PR DESCRIPTION
`console.log()` is for general purpose but the info/error/warn/debug methods are for debugging. 